### PR TITLE
Handle missing barcode scanner module and remove deprecated Babel plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,8 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['expo-router/babel', 'react-native-reanimated/plugin'],
+    // 'expo-router/babel' is deprecated since Expo SDK 50; the preset already
+    // includes the necessary configuration.
+    plugins: ['react-native-reanimated/plugin'],
   };
 };


### PR DESCRIPTION
## Summary
- drop deprecated `expo-router/babel` plugin for Expo SDK 50+
- safeguard barcode scanning route when native module isn't available

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab5234386c832fb4f4ca58b1373839