### PR TITLE
Add calendar-based dark home screen with German localisation

### DIFF
--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -7,11 +7,11 @@ import { ThemedView } from '@/components/ThemedView';
 export default function NotFoundScreen() {
   return (
     <>
-      <Stack.Screen options={{ title: 'Oops!' }} />
+      <Stack.Screen options={{ title: 'Ups!' }} />
       <ThemedView style={styles.container}>
-        <ThemedText type="title">This screen does not exist.</ThemedText>
+        <ThemedText type="title">Dieser Bildschirm existiert nicht.</ThemedText>
         <Link href="/" style={styles.link}>
-          <ThemedText type="link">Go to home screen!</ThemedText>
+          <ThemedText type="link">Zur Startseite!</ThemedText>
         </Link>
       </ThemedView>
     </>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,19 +1,17 @@
 import { Stack } from 'expo-router';
 import { PaperProvider } from 'react-native-paper';
-import { useColorScheme } from '@/hooks/useColorScheme';
-import { darkTheme, lightTheme } from '@/theme';
+import { darkTheme } from '@/theme';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
 
 export default function RootLayout() {
-  const scheme = useColorScheme();
-  const theme = scheme === 'dark' ? darkTheme : lightTheme;
+  const theme = darkTheme;
   return (
     <PaperProvider theme={theme}>
       <SafeAreaProvider>
         <SafeAreaView style={{ flex: 1, backgroundColor: theme.colors.background }}>
           <Stack screenOptions={{ headerShown: false }} />
-          <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
+          <StatusBar style="light" />
         </SafeAreaView>
       </SafeAreaProvider>
     </PaperProvider>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
-import { View, FlatList } from 'react-native';
-import { Button, List, Text, TextInput } from 'react-native-paper';
+import { View, FlatList, TouchableOpacity } from 'react-native';
+import { Button, IconButton, List, Text, TextInput, useTheme } from 'react-native-paper';
 import { useFocusEffect, useRouter } from 'expo-router';
 import { getEntries, getDailyTotalKcal, getWeightFor, setWeight, getProfile } from '@/lib/storage';
 import { FoodEntry } from '@/types';
 
 export default function Index() {
   const router = useRouter();
-  const today = new Date().toISOString().slice(0, 10);
+  const theme = useTheme();
+  const [selectedDate, setSelectedDate] = React.useState(
+    new Date().toISOString().slice(0, 10),
+  );
+  const [currentMonth, setCurrentMonth] = React.useState(() => {
+    const d = new Date();
+    return new Date(d.getFullYear(), d.getMonth(), 1);
+  });
   const [entries, setEntries] = React.useState<FoodEntry[]>([]);
   const [total, setTotal] = React.useState(0);
   const [weight, setWeightState] = React.useState('');
@@ -23,23 +30,25 @@ export default function Index() {
 
   const load = React.useCallback(() => {
     (async () => {
-      const e = await getEntries(today);
+      const e = await getEntries(selectedDate);
       setEntries(e);
-      const t = await getDailyTotalKcal(today);
+      const t = await getDailyTotalKcal(selectedDate);
       setTotal(t);
-      const w = await getWeightFor(today);
+      const w = await getWeightFor(selectedDate);
       if (w != null) {
         setWeightState(String(w));
+      } else {
+        setWeightState('');
       }
     })();
-  }, [today]);
+  }, [selectedDate]);
 
   useFocusEffect(load);
 
   async function saveWeight() {
     const num = parseFloat(weight);
     if (!isNaN(num)) {
-      await setWeight(today, num);
+      await setWeight(selectedDate, num);
     }
   }
 
@@ -50,10 +59,105 @@ export default function Index() {
     />
   );
 
+  function changeMonth(offset: number) {
+    setCurrentMonth((prev) =>
+      new Date(prev.getFullYear(), prev.getMonth() + offset, 1),
+    );
+  }
+
+  const year = currentMonth.getFullYear();
+  const month = currentMonth.getMonth();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const firstWeekday = (new Date(year, month, 1).getDay() + 6) % 7; // Monday start
+  const dayNames = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
+  const days: (number | null)[] = [];
+  for (let i = 0; i < firstWeekday; i++) days.push(null);
+  for (let d = 1; d <= daysInMonth; d++) days.push(d);
+
+  const displayDate = new Date(selectedDate).toLocaleDateString('de-DE');
+
   return (
-    <View style={{ flex: 1, padding: 16 }}>
+    <View style={{ flex: 1, padding: 16, backgroundColor: theme.colors.background }}>
+      <View style={{ marginBottom: 16 }}>
+        <View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: 8,
+          }}
+        >
+          <IconButton
+            icon="chevron-left"
+            onPress={() => changeMonth(-1)}
+            accessibilityLabel="Vorheriger Monat"
+          />
+          <Text variant="titleMedium">
+            {currentMonth.toLocaleDateString('de-DE', {
+              month: 'long',
+              year: 'numeric',
+            })}
+          </Text>
+          <IconButton
+            icon="chevron-right"
+            onPress={() => changeMonth(1)}
+            accessibilityLabel="Nächster Monat"
+          />
+        </View>
+        <View style={{ flexDirection: 'row' }}>
+          {dayNames.map((d) => (
+            <Text
+              key={d}
+              style={{
+                width: `${100 / 7}%`,
+                textAlign: 'center',
+                color: theme.colors.onBackground,
+              }}
+            >
+              {d}
+            </Text>
+          ))}
+        </View>
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+          {days.map((d, idx) => {
+            const dateStr = d
+              ? new Date(year, month, d).toISOString().slice(0, 10)
+              : '';
+            const selected = d && dateStr === selectedDate;
+            return (
+              <TouchableOpacity
+                key={idx}
+                style={{ width: `${100 / 7}%`, padding: 4 }}
+                onPress={() => d && setSelectedDate(dateStr)}
+              >
+                <View
+                  style={{
+                    aspectRatio: 1,
+                    borderRadius: 16,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    backgroundColor: selected
+                      ? theme.colors.primary
+                      : 'transparent',
+                  }}
+                >
+                  <Text
+                    style={{
+                      color: selected
+                        ? theme.colors.onPrimary || '#fff'
+                        : theme.colors.onBackground,
+                    }}
+                  >
+                    {d ?? ''}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </View>
       <Text variant="headlineMedium" style={{ marginBottom: 16 }}>
-        Heute: {total} kcal
+        {displayDate}: {total} kcal
       </Text>
       <FlatList
         data={entries}
@@ -72,14 +176,14 @@ export default function Index() {
       <Button
         mode="contained"
         style={{ marginTop: 16 }}
-        onPress={() => router.push('/search')}
+        onPress={() => router.push({ pathname: '/search', params: { date: selectedDate } })}
       >
         Lebensmittel suchen
       </Button>
       <Button
         mode="contained"
         style={{ marginTop: 8 }}
-        onPress={() => router.push('/scan')}
+        onPress={() => router.push({ pathname: '/scan', params: { date: selectedDate } })}
       >
         Barcode scannen
       </Button>

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { ScrollView } from 'react-native';
-import { Button, TextInput } from 'react-native-paper';
+import { Button, TextInput, useTheme } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 import { saveProfile, setWeight } from '@/lib/storage';
 
 export default function Onboarding() {
   const router = useRouter();
+  const theme = useTheme();
   const [name, setName] = React.useState('');
   const [gender, setGender] = React.useState('');
   const [height, setHeight] = React.useState('');
@@ -32,7 +33,10 @@ export default function Onboarding() {
   }
 
   return (
-    <ScrollView contentContainerStyle={{ padding: 16 }}>
+    <ScrollView
+      style={{ flex: 1, backgroundColor: theme.colors.background }}
+      contentContainerStyle={{ padding: 16 }}
+    >
       <TextInput label="Name" value={name} onChangeText={setName} style={{ marginBottom: 12 }} />
       <TextInput label="Geschlecht" value={gender} onChangeText={setGender} style={{ marginBottom: 12 }} />
       <TextInput label="Größe (cm)" value={height} onChangeText={setHeight} keyboardType="numeric" style={{ marginBottom: 12 }} />

--- a/app/scan.tsx
+++ b/app/scan.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View } from 'react-native';
-import { Button, Dialog, Portal, Text, TextInput } from 'react-native-paper';
-import { useRouter } from 'expo-router';
+import { Button, Dialog, Portal, Text, TextInput, useTheme } from 'react-native-paper';
+import { useRouter, useLocalSearchParams } from 'expo-router';
 import { fetchProduct, calculateKcal, Product } from '@/lib/off';
 import { addEntry } from '@/lib/storage';
 
@@ -16,6 +16,10 @@ try {
 
 export default function Scan() {
   const router = useRouter();
+  const { date } = useLocalSearchParams<{ date?: string }>();
+  const entryDate =
+    typeof date === 'string' ? date : new Date().toISOString().slice(0, 10);
+  const theme = useTheme();
   const [hasPermission, setHasPermission] = React.useState<boolean | null>(null);
   const [scanned, setScanned] = React.useState(false);
   const [product, setProduct] = React.useState<Product | null>(null);
@@ -48,7 +52,7 @@ export default function Scan() {
     const g = parseFloat(grams);
     if (isNaN(g)) return;
     await addEntry({
-      date: new Date().toISOString().slice(0, 10),
+      date: entryDate,
       code: product.code,
       name: product.name,
       grams: g,
@@ -59,17 +63,29 @@ export default function Scan() {
   }
 
   if (!BarCodeScanner) {
-    return <Text>Barcode scanning is not supported on this platform.</Text>;
+    return (
+      <View
+        style={{ flex: 1, backgroundColor: theme.colors.background, justifyContent: 'center', alignItems: 'center' }}
+      >
+        <Text>Barcode-Scannen wird auf dieser Plattform nicht unterstützt.</Text>
+      </View>
+    );
   }
   if (hasPermission === null) {
-    return <View style={{ flex: 1 }} />;
+    return <View style={{ flex: 1, backgroundColor: theme.colors.background }} />;
   }
   if (hasPermission === false) {
-    return <Text>Keine Kameraberechtigung</Text>;
+    return (
+      <View
+        style={{ flex: 1, backgroundColor: theme.colors.background, justifyContent: 'center', alignItems: 'center' }}
+      >
+        <Text>Keine Kameraberechtigung</Text>
+      </View>
+    );
   }
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
       {!product && BarCodeScanner && (
         <BarCodeScanner
           onBarCodeScanned={handleBarCodeScanned}

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { View, FlatList } from 'react-native';
-import { Button, Dialog, List, Portal, TextInput } from 'react-native-paper';
-import { useRouter } from 'expo-router';
+import { Button, Dialog, List, Portal, TextInput, useTheme } from 'react-native-paper';
+import { useRouter, useLocalSearchParams } from 'expo-router';
 import { searchProducts, calculateKcal, Product } from '@/lib/off';
 import { addEntry } from '@/lib/storage';
 
 export default function Search() {
   const router = useRouter();
+  const { date } = useLocalSearchParams<{ date?: string }>();
+  const entryDate =
+    typeof date === 'string' ? date : new Date().toISOString().slice(0, 10);
+  const theme = useTheme();
   const [query, setQuery] = React.useState('');
   const [results, setResults] = React.useState<Product[]>([]);
   const [selected, setSelected] = React.useState<Product | null>(null);
@@ -22,7 +26,7 @@ export default function Search() {
     const g = parseFloat(grams);
     if (isNaN(g)) return;
     await addEntry({
-      date: new Date().toISOString().slice(0, 10),
+      date: entryDate,
       code: selected.code,
       name: selected.name,
       grams: g,
@@ -33,7 +37,7 @@ export default function Search() {
   }
 
   return (
-    <View style={{ flex: 1, padding: 16 }}>
+    <View style={{ flex: 1, padding: 16, backgroundColor: theme.colors.background }}>
       <TextInput
         label="Suche"
         value={query}

--- a/lib/off.ts
+++ b/lib/off.ts
@@ -28,7 +28,9 @@ export function calculateKcal(grams: number, kcalPer100g: number): number {
 }
 
 export async function searchProducts(query: string): Promise<Product[]> {
-  const url = `${BASE_URL}/search?general_search=${encodeURIComponent(query)}&fields=code,product_name,nutriments&page_size=10`;
+  const url = `${BASE_URL}/search?general_search=${encodeURIComponent(
+    query,
+  )}&fields=code,product_name,nutriments&page_size=10&lc=de`;
   const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT } });
   const json = await res.json();
   return (json.products || []).map((p: OFFProduct) => ({
@@ -39,7 +41,7 @@ export async function searchProducts(query: string): Promise<Product[]> {
 }
 
 export async function fetchProduct(barcode: string): Promise<Product | null> {
-  const url = `${BASE_URL}/product/${barcode}?fields=code,product_name,nutriments`;
+  const url = `${BASE_URL}/product/${barcode}?fields=code,product_name,nutriments&lc=de`;
   const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT } });
   const json = await res.json();
   const p: OFFProduct | undefined = json.product;


### PR DESCRIPTION
## Summary
- enforce dark theme across app for better readability
- show calendar home screen to pick dates and view entries
- request German product names from OpenFoodFacts and translate UI strings

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab549b4f90832fb8c1ebac91b57b6e