### PR TITLE
Fix product search query parameter

### DIFF
--- a/lib/off.ts
+++ b/lib/off.ts
@@ -28,7 +28,7 @@ export function calculateKcal(grams: number, kcalPer100g: number): number {
 }
 
 export async function searchProducts(query: string): Promise<Product[]> {
-  const url = `${BASE_URL}/search?general_search=${encodeURIComponent(
+  const url = `${BASE_URL}/search?search_terms=${encodeURIComponent(
     query,
   )}&fields=code,product_name,nutriments&page_size=10&lc=de`;
   const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT } });


### PR DESCRIPTION
## Summary
- use `search_terms` parameter for OpenFoodFacts search so queries return specific products

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab5ff43e68832f996469b1854d84e9