### PR TITLE
Switch to OpenFoodFacts data API and add gender dropdown

### DIFF
--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ScrollView } from 'react-native';
-import { Button, TextInput, useTheme } from 'react-native-paper';
+import { Button, TextInput, useTheme, Menu } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 import { saveProfile, setWeight } from '@/lib/storage';
 
@@ -9,6 +9,7 @@ export default function Onboarding() {
   const theme = useTheme();
   const [name, setName] = React.useState('');
   const [gender, setGender] = React.useState('');
+  const [genderMenuVisible, setGenderMenuVisible] = React.useState(false);
   const [height, setHeight] = React.useState('');
   const [weight, setWeightInput] = React.useState('');
   const [age, setAge] = React.useState('');
@@ -38,7 +39,42 @@ export default function Onboarding() {
       contentContainerStyle={{ padding: 16 }}
     >
       <TextInput label="Name" value={name} onChangeText={setName} style={{ marginBottom: 12 }} />
-      <TextInput label="Geschlecht" value={gender} onChangeText={setGender} style={{ marginBottom: 12 }} />
+      <Menu
+        visible={genderMenuVisible}
+        onDismiss={() => setGenderMenuVisible(false)}
+        anchor={
+          <TextInput
+            label="Geschlecht"
+            value={gender}
+            onFocus={() => setGenderMenuVisible(true)}
+            showSoftInputOnFocus={false}
+            right={<TextInput.Icon icon="menu-down" />}
+            style={{ marginBottom: 12 }}
+          />
+        }
+      >
+        <Menu.Item
+          onPress={() => {
+            setGender('m');
+            setGenderMenuVisible(false);
+          }}
+          title="m"
+        />
+        <Menu.Item
+          onPress={() => {
+            setGender('w');
+            setGenderMenuVisible(false);
+          }}
+          title="w"
+        />
+        <Menu.Item
+          onPress={() => {
+            setGender('d');
+            setGenderMenuVisible(false);
+          }}
+          title="d"
+        />
+      </Menu>
       <TextInput label="Größe (cm)" value={height} onChangeText={setHeight} keyboardType="numeric" style={{ marginBottom: 12 }} />
       <TextInput label="Gewicht (kg)" value={weight} onChangeText={setWeightInput} keyboardType="numeric" style={{ marginBottom: 12 }} />
       <TextInput label="Alter" value={age} onChangeText={setAge} keyboardType="numeric" style={{ marginBottom: 12 }} />

--- a/lib/off.ts
+++ b/lib/off.ts
@@ -1,4 +1,4 @@
-const BASE_URL = 'https://world.openfoodfacts.org/api/v2';
+const BASE_URL = 'https://openfoodfacts.org/data';
 const USER_AGENT = 'foodtrack-mvp/1.0';
 
 export interface Product {


### PR DESCRIPTION
## Summary
- pull product data from the openfoodfacts.org/data API
- offer m/w/d gender selection in onboarding

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab64a098d8832f8bb6d827831587a9