### PR TITLE
Add BMR calculation and daily entry management

### DIFF
--- a/lib/bmr.ts
+++ b/lib/bmr.ts
@@ -1,0 +1,8 @@
+import { Profile } from './storage';
+
+export function calculateBMR(profile: Profile, weightKg: number): number {
+  const s = profile.gender === 'male' ? 5 : -161;
+  return Math.round(
+    10 * weightKg + 6.25 * profile.heightCm - 5 * profile.age + s,
+  );
+}

--- a/lib/off.ts
+++ b/lib/off.ts
@@ -1,5 +1,10 @@
-const BASE_URL = 'https://openfoodfacts.org/data';
 const USER_AGENT = 'foodtrack-mvp/1.0';
+
+function getBaseUrl(category: 'Food' | 'Beauty' = 'Food'): string {
+  return category === 'Food'
+    ? 'https://world.openfoodfacts.org'
+    : 'https://world.openbeautyfacts.org';
+}
 
 export interface Product {
   code: string;
@@ -27,10 +32,14 @@ export function calculateKcal(grams: number, kcalPer100g: number): number {
   return Math.round((grams * kcalPer100g) / 100);
 }
 
-export async function searchProducts(query: string): Promise<Product[]> {
-  const url = `${BASE_URL}/search?search_terms=${encodeURIComponent(
-    query,
-  )}&fields=code,product_name,nutriments&page_size=10&lc=de`;
+export async function searchProducts(
+  query: string,
+  category: 'Food' | 'Beauty' = 'Food',
+): Promise<Product[]> {
+  const base = getBaseUrl(category);
+  const url =
+    `${base}/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&json=1` +
+    '&fields=code,product_name,nutriments&page_size=10&lc=de';
   const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT } });
   const json = await res.json();
   return (json.products || []).map((p: OFFProduct) => ({
@@ -40,8 +49,12 @@ export async function searchProducts(query: string): Promise<Product[]> {
   }));
 }
 
-export async function fetchProduct(barcode: string): Promise<Product | null> {
-  const url = `${BASE_URL}/product/${barcode}?fields=code,product_name,nutriments&lc=de`;
+export async function fetchProduct(
+  barcode: string,
+  category: 'Food' | 'Beauty' = 'Food',
+): Promise<Product | null> {
+  const base = getBaseUrl(category);
+  const url = `${base}/api/v0/product/${barcode}.json`;
   const res = await fetch(url, { headers: { 'User-Agent': USER_AGENT } });
   const json = await res.json();
   const p: OFFProduct | undefined = json.product;

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -41,6 +41,38 @@ export async function addEntry(entry: FoodEntry): Promise<void> {
   await AsyncStorage.setItem(ENTRIES_KEY, JSON.stringify(entries));
 }
 
+export async function updateEntry(
+  date: string,
+  idx: number,
+  entry: FoodEntry,
+): Promise<void> {
+  const entries = await getAllEntries();
+  let count = -1;
+  for (let i = 0; i < entries.length; i++) {
+    if (entries[i].date === date) {
+      count++;
+      if (count === idx) {
+        entries[i] = entry;
+        break;
+      }
+    }
+  }
+  await AsyncStorage.setItem(ENTRIES_KEY, JSON.stringify(entries));
+}
+
+export async function removeEntry(date: string, idx: number): Promise<void> {
+  const entries = await getAllEntries();
+  let count = -1;
+  const filtered = entries.filter((e) => {
+    if (e.date === date) {
+      count++;
+      return count !== idx;
+    }
+    return true;
+  });
+  await AsyncStorage.setItem(ENTRIES_KEY, JSON.stringify(filtered));
+}
+
 export async function getEntries(date: string): Promise<FoodEntry[]> {
   const entries = await getAllEntries();
   return entries.filter((e) => e.date === date);


### PR DESCRIPTION
## Summary
- switch Open Food Facts API to world endpoints
- compute daily BMR from profile and weight and show difference to intake
- allow editing and deleting day entries with icons and fullscreen modal

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab6707f0c8832fa1c3edc6f441793a