### PR TITLE
fix: use CORS-enabled Open Food Facts endpoint

### DIFF
--- a/lib/off.ts
+++ b/lib/off.ts
@@ -2,8 +2,8 @@ const USER_AGENT = 'foodtrack-mvp/1.0';
 
 function getBaseUrl(category: 'Food' | 'Beauty' = 'Food'): string {
   return category === 'Food'
-    ? 'https://world.openfoodfacts.org'
-    : 'https://world.openbeautyfacts.org';
+    ? 'https://world.openfoodfacts.net'
+    : 'https://world.openbeautyfacts.net';
 }
 
 export interface Product {


### PR DESCRIPTION
## Summary
- update Open Food Facts base URLs to .net domain so responses include CORS headers

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab773074f0832fa14010d537ff886c