### PR TITLE
Add meal grouping and streamlined entry flow

### DIFF
--- a/app/scan.tsx
+++ b/app/scan.tsx
@@ -18,9 +18,13 @@ try {
 
 export default function Scan() {
   const router = useRouter();
-  const { date } = useLocalSearchParams<{ date?: string }>();
+  const { date, meal } = useLocalSearchParams<{ date?: string; meal?: string }>();
   const entryDate =
     typeof date === 'string' ? date : new Date().toISOString().slice(0, 10);
+  const mealType =
+    meal === 'breakfast' || meal === 'lunch' || meal === 'dinner' || meal === 'snack'
+      ? meal
+      : 'snack';
   const theme = useTheme();
   const [hasPermission, setHasPermission] = React.useState<boolean | null>(null);
   const [scanned, setScanned] = React.useState(false);
@@ -59,9 +63,10 @@ export default function Scan() {
       name: product.name,
       grams: g,
       kcal: calculateKcal(g, product.kcal100),
+      mealType,
     });
     setProduct(null);
-    router.back();
+    router.replace({ pathname: '/', params: { date: entryDate, open: '1' } });
   }
 
   if (!BarCodeScanner) {

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -7,9 +7,13 @@ import { addEntry } from '@/lib/storage';
 
 export default function Search() {
   const router = useRouter();
-  const { date } = useLocalSearchParams<{ date?: string }>();
+  const { date, meal } = useLocalSearchParams<{ date?: string; meal?: string }>();
   const entryDate =
     typeof date === 'string' ? date : new Date().toISOString().slice(0, 10);
+  const mealType =
+    meal === 'breakfast' || meal === 'lunch' || meal === 'dinner' || meal === 'snack'
+      ? meal
+      : 'snack';
   const theme = useTheme();
   const [query, setQuery] = React.useState('');
   const [results, setResults] = React.useState<Product[]>([]);
@@ -31,6 +35,7 @@ export default function Search() {
       name: selected.name,
       grams: g,
       kcal: calculateKcal(g, selected.kcal100),
+      mealType,
     });
     setSelected(null);
     router.replace({ pathname: '/', params: { date: entryDate, open: '1' } });

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -15,6 +15,7 @@ export interface FoodEntry {
   name: string;
   grams: number;
   kcal: number;
+  mealType: 'breakfast' | 'lunch' | 'dinner' | 'snack';
 }
 
 const PROFILE_KEY = 'profile';
@@ -82,7 +83,12 @@ export async function removeEntry(date: string, idx: number): Promise<void> {
 
 export async function getEntries(date: string): Promise<FoodEntry[]> {
   const entries = await getAllEntries();
-  return entries.filter((e) => e.date === date);
+  return entries
+    .filter((e) => e.date === date)
+    .map((e) => ({
+      ...e,
+      mealType: e.mealType ?? 'snack',
+    }));
 }
 
 export async function getDailyTotalKcal(date: string): Promise<number> {

--- a/theme.ts
+++ b/theme.ts
@@ -7,6 +7,7 @@ export const darkTheme = {
     primary: '#ff8c1a',
     secondary: '#ff8c1a',
     background: '#0d0f14',
+    error: '#ff1744',
   },
 };
 
@@ -16,6 +17,7 @@ export const lightTheme = {
     ...MD3LightTheme.colors,
     primary: '#ff8c1a',
     secondary: '#ff8c1a',
+    error: '#ff1744',
   },
 };
 


### PR DESCRIPTION
## Summary
- Group daily entries by meal type with per-group calorie totals
- Introduce unified add-entry dialog with search and barcode scan
- Allow editing only grams with automatic kcal recalculation
- Apply consistent orange theme and stronger error red

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac524f9d1c832f9034213ca342223e