### PR TITLE
Fix OpenFoodFacts endpoints and fullscreen food modal

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -475,10 +475,19 @@ export default function Index() {
             </View>
           </View>
         </Modal>
-        <Dialog visible={addDialog} onDismiss={() => setAddDialog(false)}>
-          <Dialog.Title>Neuer Eintrag</Dialog.Title>
-          <Dialog.Content>
+        <Modal
+          visible={addDialog}
+          onDismiss={() => setAddDialog(false)}
+          contentContainerStyle={{
+            flex: 1,
+            backgroundColor: theme.colors.background,
+            padding: 16,
+          }}
+        >
+          <View style={{ flex: 1 }}>
+            <Text variant="titleLarge">Neuer Eintrag</Text>
             <SegmentedButtons
+              style={{ marginTop: 16 }}
               value={mealType}
               onValueChange={(v) =>
                 setMealType(v as 'breakfast' | 'lunch' | 'dinner' | 'snack')
@@ -516,7 +525,7 @@ export default function Index() {
                 }}
               />
             </View>
-            <ScrollView style={{ maxHeight: 200, marginTop: 16 }}>
+            <ScrollView style={{ flex: 1, marginTop: 16 }}>
               {results.map((item) => (
                 <List.Item
                   key={item.code}
@@ -529,11 +538,9 @@ export default function Index() {
                 />
               ))}
             </ScrollView>
-          </Dialog.Content>
-          <Dialog.Actions>
             <Button onPress={() => setAddDialog(false)}>Schließen</Button>
-          </Dialog.Actions>
-        </Dialog>
+          </View>
+        </Modal>
         <Dialog
           visible={!!selectedProduct}
           onDismiss={() => setSelectedProduct(null)}

--- a/lib/off.ts
+++ b/lib/off.ts
@@ -2,8 +2,8 @@ const USER_AGENT = 'foodtrack-mvp/1.0';
 
 function getBaseUrl(category: 'Food' | 'Beauty' = 'Food'): string {
   return category === 'Food'
-    ? 'https://world.openfoodfacts.net'
-    : 'https://world.openbeautyfacts.net';
+    ? 'https://world.openfoodfacts.org'
+    : 'https://world.openbeautyfacts.org';
 }
 
 export interface Product {


### PR DESCRIPTION
## Summary
- point OpenFoodFacts requests to `.org` domains
- show the add-food dialog as a fullscreen modal

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac747b05f0832f8dd6883a9d502c46