### PR TITLE
Add barcode scanner interface dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/native": "^7.1.6",
         "expo": "~53.0.22",
         "expo-barcode-scanner": "^13.0.1",
+        "expo-barcode-scanner-interface": "^3.0.0",
         "expo-blur": "~14.1.5",
         "expo-constants": "~17.1.7",
         "expo-font": "~13.3.2",
@@ -6217,6 +6218,12 @@
       "peerDependencies": {
         "expo": "*"
       }
+    },
+    "node_modules/expo-barcode-scanner-interface": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/expo-barcode-scanner-interface/-/expo-barcode-scanner-interface-3.0.0.tgz",
+      "integrity": "sha512-uBOPSNk8Bd3kgcDRozAUe9GSFvSBXgymJOKhPFQAIO5w6IDTfpTpse9xgwOa9WShU4EypDvrXb5WTXSCdbrCwg==",
+      "license": "MIT"
     },
     "node_modules/expo-blur": {
       "version": "14.1.5",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@react-navigation/native": "^7.1.6",
     "expo": "~53.0.22",
     "expo-barcode-scanner": "^13.0.1",
+    "expo-barcode-scanner-interface": "^3.0.0",
     "expo-blur": "~14.1.5",
     "expo-constants": "~17.1.7",
     "expo-font": "~13.3.2",


### PR DESCRIPTION
## Summary
- add `expo-barcode-scanner-interface` dependency so Android release builds can compile

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acd345b49c832fbef157851098eb34