### PR TITLE
Fix app.json merge conflict for Android permissions

### DIFF
--- a/app.json
+++ b/app.json
@@ -27,13 +27,10 @@
     },
     "android": {
       "package": "org.systemkritisch.foodtrack",
-<<<<<<< HEAD
-=======
       "permissions": [
         "CAMERA",
         "android.permission.CAMERA"
       ],
->>>>>>> 4ce1aec (eas)
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"


### PR DESCRIPTION
## Summary
- resolve merge conflict markers in app.json
- add explicit Android camera permissions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx expo config --json`


------
https://chatgpt.com/codex/tasks/task_e_68af4659a598832fb0ecca69ec0b2fda