### PR TITLE
Fix CORS search and disable mobile autocorrect

### DIFF
--- a/app/search.tsx
+++ b/app/search.tsx
@@ -49,6 +49,9 @@ export default function Search() {
         onChangeText={setQuery}
         onSubmitEditing={performSearch}
         right={<TextInput.Icon icon="magnify" onPress={performSearch} />}
+        autoCorrect={false}
+        autoCapitalize="none"
+        autoComplete="off"
       />
       <FlatList
         data={results}

--- a/lib/off.ts
+++ b/lib/off.ts
@@ -11,10 +11,12 @@ function fetchOFF(url: string): Promise<Response> {
   return fetch(url);
 }
 
+// The `.net` domains return the proper CORS headers required for browser
+// requests while the `.org` domains do not.
 function getBaseUrl(category: 'Food' | 'Beauty' = 'Food'): string {
   return category === 'Food'
-    ? 'https://world.openfoodfacts.org'
-    : 'https://world.openbeautyfacts.org';
+    ? 'https://world.openfoodfacts.net'
+    : 'https://world.openbeautyfacts.net';
 }
 
 export interface Product {


### PR DESCRIPTION
## Summary
- use OpenFoodFacts .net domains which send CORS headers
- disable autocomplete and autocorrect for search input

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af77283000832f8d8ed48468938621