### PR TITLE
Improve day navigation and calendar styling

### DIFF
--- a/app/search.tsx
+++ b/app/search.tsx
@@ -38,7 +38,7 @@ export default function Search() {
       mealType,
     });
     setSelected(null);
-    router.replace({ pathname: '/day/[date]', params: { date: entryDate } });
+    router.back();
   }
 
   return (


### PR DESCRIPTION
## Summary
- Mark current day and days with entries or weight in calendar
- Style day header to match calendar and animate swipe transitions
- Return to calendar with a single back after adding entries

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b175182820832f9025d3905b389dc1