### PR TITLE
Fix date handling and day marking in calendar

### DIFF
--- a/app/day/[date].tsx
+++ b/app/day/[date].tsx
@@ -24,6 +24,7 @@ import {
 } from '@/lib/storage';
 import { calculateBMR } from '@/lib/bmr';
 import { FoodEntry } from '@/types';
+import { formatDate } from '@/lib/date';
 
 export default function DayView() {
   const router = useRouter();
@@ -31,7 +32,7 @@ export default function DayView() {
   const initialDate =
     typeof dateParam === 'string'
       ? dateParam
-      : new Date().toISOString().slice(0, 10);
+      : formatDate(new Date());
   const theme = useTheme();
   const [selectedDate, setSelectedDate] = React.useState(initialDate);
   const [entries, setEntries] = React.useState<FoodEntry[]>([]);
@@ -100,7 +101,7 @@ export default function DayView() {
     (delta: number) => {
       const d = new Date(selectedDate);
       d.setDate(d.getDate() + delta);
-      setSelectedDate(d.toISOString().slice(0, 10));
+      setSelectedDate(formatDate(d));
     },
     [selectedDate],
   );

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { View, TouchableOpacity } from 'react-native';
 import { IconButton, Text, useTheme } from 'react-native-paper';
 import { useRouter } from 'expo-router';
-import { getEntries, getWeightFor } from '@/lib/storage';
+import { getEntries, hasWeight } from '@/lib/storage';
+import { formatDate } from '@/lib/date';
 
 export default function Index() {
   const router = useRouter();
@@ -20,10 +21,10 @@ export default function Index() {
       const month = currentMonth.getMonth();
       const daysInMonth = new Date(year, month + 1, 0).getDate();
       for (let d = 1; d <= daysInMonth; d++) {
-        const dateStr = new Date(year, month, d).toISOString().slice(0, 10);
+        const dateStr = formatDate(new Date(year, month, d));
         const e = await getEntries(dateStr);
-        const w = await getWeightFor(dateStr);
-        if (e.length > 0 || w != null) {
+        const w = await hasWeight(dateStr);
+        if (e.length > 0 || w) {
           record[dateStr] = true;
         }
       }
@@ -47,7 +48,7 @@ export default function Index() {
   const days: (number | null)[] = [];
   for (let i = 0; i < firstWeekday; i++) days.push(null);
   for (let d = 1; d <= daysInMonth; d++) days.push(d);
-  const todayStr = new Date().toISOString().slice(0, 10);
+  const todayStr = formatDate(new Date());
 
   return (
     <View
@@ -94,9 +95,7 @@ export default function Index() {
       </View>
       <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
         {days.map((d, idx) => {
-          const dateStr = d
-            ? new Date(year, month, d).toISOString().slice(0, 10)
-            : '';
+          const dateStr = d ? formatDate(new Date(year, month, d)) : '';
           const hasData = d && markedDays[dateStr];
           const isToday = d && dateStr === todayStr;
           return (

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -3,6 +3,7 @@ import { ScrollView } from 'react-native';
 import { Button, TextInput, useTheme, Menu } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 import { saveProfile, setWeight } from '@/lib/storage';
+import { formatDate } from '@/lib/date';
 
 export default function Onboarding() {
   const router = useRouter();
@@ -35,7 +36,7 @@ export default function Onboarding() {
     await saveProfile(profile);
     const w = parseFloat(weight);
     if (!isNaN(w)) {
-      const today = new Date().toISOString().slice(0, 10);
+      const today = formatDate(new Date());
       await setWeight(today, w);
     }
     router.replace('/');

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -4,12 +4,12 @@ import { Button, Dialog, List, Portal, TextInput, useTheme } from 'react-native-
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { searchProducts, calculateKcal, Product } from '@/lib/off';
 import { addEntry } from '@/lib/storage';
+import { formatDate } from '@/lib/date';
 
 export default function Search() {
   const router = useRouter();
   const { date, meal } = useLocalSearchParams<{ date?: string; meal?: string }>();
-  const entryDate =
-    typeof date === 'string' ? date : new Date().toISOString().slice(0, 10);
+  const entryDate = typeof date === 'string' ? date : formatDate(new Date());
   const mealType =
     meal === 'breakfast' || meal === 'lunch' || meal === 'dinner' || meal === 'snack'
       ? meal

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,0 +1,6 @@
+export function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { formatDate } from './date';
 
 export interface Profile {
   name: string;
@@ -52,7 +53,7 @@ export async function addEntry(entry: FoodEntry): Promise<void> {
 export async function updateEntry(
   date: string,
   idx: number,
-  entry: FoodEntry,
+  entry: Partial<FoodEntry>,
 ): Promise<void> {
   const entries = await getAllEntries();
   let count = -1;
@@ -60,7 +61,7 @@ export async function updateEntry(
     if (entries[i].date === date) {
       count++;
       if (count === idx) {
-        entries[i] = entry;
+        entries[i] = { ...entries[i], ...entry };
         break;
       }
     }
@@ -115,7 +116,7 @@ export async function getWeightFor(date: string): Promise<number | null> {
   let d = new Date(date);
   while (true) {
     d.setDate(d.getDate() - 1);
-    const key = d.toISOString().slice(0, 10);
+    const key = formatDate(d);
     if (weights[key] != null) {
       return weights[key];
     }
@@ -125,4 +126,9 @@ export async function getWeightFor(date: string): Promise<number | null> {
   }
   const profile = await getProfile();
   return profile ? profile.weightKgInitial : null;
+}
+
+export async function hasWeight(date: string): Promise<boolean> {
+  const weights = await getAllWeights();
+  return weights[date] != null;
 }


### PR DESCRIPTION
## Summary
- add helper to produce YYYY-MM-DD dates in local time
- mark calendar days only when entries or weights exist
- use local date formatting across app to avoid timezone issues

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b17975e664832f874ffa86a93ec150